### PR TITLE
fix rworldmap / elide warnings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '71501411'
+ValidationKey: '71528436'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'luplot: Landuse Plot Library'
-version: 3.61.1
-date-released: '2024-03-19'
+version: 3.61.2
+date-released: '2024-03-21'
 abstract: Some useful functions to plot data such as a map plot function for MAgPIE
   objects.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: luplot
 Title: Landuse Plot Library
-Version: 3.61.1
-Date: 2024-03-19
+Version: 3.61.2
+Date: 2024-03-21
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),
@@ -38,7 +38,7 @@ Imports:
     mip,
     quitte,
     reshape2,
-    rworldmap,
+    rworldmap (>= 1.3.8),
     sp,
     xml2,
     gridExtra,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Landuse Plot Library
 
-R package **luplot**, version **3.61.1**
+R package **luplot**, version **3.61.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/luplot)](https://cran.r-project.org/package=luplot)  [![R build status](https://github.com/pik-piam/luplot/workflows/check/badge.svg)](https://github.com/pik-piam/luplot/actions) [![codecov](https://codecov.io/gh/pik-piam/luplot/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/luplot) [![r-universe](https://pik-piam.r-universe.dev/badges/luplot)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Bodirsky <bodirsky@pik-p
 
 To cite package **luplot** in publications use:
 
-Bodirsky B, Dietrich J, Krause M, Stevanovic M, Humpenoeder F, Weindl I, Baumstark L, Klein D, Rolinski S, Wang X, Chen D (2024). _luplot: Landuse Plot Library_. R package version 3.61.1, <URL: https://github.com/pik-piam/luplot>.
+Bodirsky B, Dietrich J, Krause M, Stevanovic M, Humpenoeder F, Weindl I, Baumstark L, Klein D, Rolinski S, Wang X, Chen D (2024). _luplot: Landuse Plot Library_. R package version 3.61.2, <URL: https://github.com/pik-piam/luplot>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {luplot: Landuse Plot Library},
   author = {Benjamin Leon Bodirsky and Jan Philipp Dietrich and Michael Krause and Miodrag Stevanovic and Florian Humpenoeder and Isabelle Weindl and Lavinia Baumstark and David Klein and Susanne Rolinski and Xiaoxi Wang and David Chen},
   year = {2024},
-  note = {R package version 3.61.1},
+  note = {R package version 3.61.2},
   url = {https://github.com/pik-piam/luplot},
 }
 ```


### PR DESCRIPTION
- we need `rworldmap (>= 1.3.8)` because [in this version, the dependency on maptools was removed](https://github.com/andysouth/rworldmap/commit/09f9a144909aa2a42712ccac279fafd36a562c75#diff-b6b6854a02ae177f8860f49654ff250c1554d021ae434b6efdbe99d00bdc6055).
- maptools creates a `Warning: multiple methods tables found for ‘elide’` problem if used together with `sp` since they copied the [`elide` method from maptools](https://github.com/edzer/sp/commit/37ab639c4aded9c8179a0d1051378f83117a8074)